### PR TITLE
Create CI/CD workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,8 @@ name: Pipeline build
 
 on:
   push:
+    paths:
+      - 'src/backend'
     branches:
       - '*'
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -28,8 +28,8 @@ jobs:
         uses: 'google-github-actions/auth@v0'
         with:
           token_format: 'access_token'
-          workload_identity_provider: 'projects/389517956549/locations/global/workloadIdentityPools/github/providers/github-provider' # e.g. - projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider
-          service_account: 'github-493@terrafarm-378218.iam.gserviceaccount.com' # e.g. - my-service-account@my-project.iam.gserviceaccount.com
+          workload_identity_provider: 'projects/389517956549/locations/global/workloadIdentityPools/github/providers/github-provider'
+          service_account: 'github-493@terrafarm-378218.iam.gserviceaccount.com' 
           
       # Authenticate Docker to Google Cloud Artifact Registry
       - name: Docker Auth
@@ -40,6 +40,7 @@ jobs:
           password: '${{ steps.auth.outputs.access_token }}'
           registry: '${{ env.GAR_LOCATION }}-docker.pkg.dev'
 
+      # Build the container and then push it to the Artifact Registry
       - name: Build and Push to GAR
         run: |-
           cd src/backend

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Build and Push to GAR
         run: |-
           cd src/backend
-          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}:${{ github.sha }}" ./
-          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}:${{ github.sha }}"
+          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/latest:${{ github.sha }}" ./
+          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/latest:${{ github.sha }}"
 
       # If required, use the Cloud Run url output in later steps
       - name: Show Output

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build and Push to GAR
         run: |-
-          cd src/backend ./
+          cd src/backend
           docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}:${{ github.sha }}" ./
           docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}:${{ github.sha }}"
 

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -35,6 +35,9 @@ python -m mypy . --explicit-package-bases
 python -m pylint ../pipeline
 ```
 
+### CI/CD
+The CI/CD pushes the build from the latest commit to the `pipelines-dev` repository in the Google Artifact Registry.
+
 ### Modules
 To make the code extendible, maintainable, and multithreaded, the pipeline is divided into modules. Modules are run sequentially, and each can have multiple implementations that execute different logic, but compute the same type of data. We distinguish the following modules:
 - Mosaicing module - transforms the flyover images into a single farmland bird's eye view image


### PR DESCRIPTION
Builds the pipeline image using the `Dockerfile` at `src/backend/Dockerfile`, and pushes it to the Artifact Registry with the `latest` name.

The Google Artifact Registry repository is [**here**](https://console.cloud.google.com/artifacts/docker/terrafarm-378218/europe-west4/pipelines-dev?project=terrafarm-378218).